### PR TITLE
Simplify gradual font size (molten leading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ The origin and motivation of each ruleset is detailed below:
   from an original idea by Tim Brown ([@tbrown](https://github.com/tbrown)):  
   Size text according to screen width
   ```css
-  html { font-size: 16px; }
-  @media (min-width: 600px) { html { font-size: calc(0.4vw + 13.6px) } }
+  html { font-size: clamp(0.9rem, calc(13px + 0.5vw), 1.1rem); }
   ```
   These rules allow text to resize dynamically to adapt to the width of the container.
   It's the same concept as [flowtype.js](https://simplefocus.com/flowtype/),

--- a/downstyler.css
+++ b/downstyler.css
@@ -17,8 +17,7 @@ html { box-sizing: border-box; } *, *:before, *:after { box-sizing: inherit; }
 /* ---------------------------------------------------------------------------------------------- */
 /* Size text according to screen width (adapted from https://css-tricks.com/molten-leading-css/)  */
 /* ---------------------------------------------------------------------------------------------- */
-html { font-size: 16px; }
-@media (min-width: 600px) { html { font-size: calc(13px + 0.5vw) } }
+html { font-size: clamp(0.9rem, calc(13px + 0.5vw), 1.1rem); }
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Improved typography (adapted from http://bettermotherfuckingwebsite.com)                       */


### PR DESCRIPTION
`min()`, `max()` and `clamp()` are [now available in major browsers](https://caniuse.com/#feat=mdn-css_types_clamp) (since Edge 79, released 15 Jan 2020; FF 75, released 8 Apr 2020; and Chrome 79 released 10 Dec 2019) so we can use it instead of a media query to make the font size adapt to the viewport size.

Using `clamp()` also allows us to introduce a maximum font size as well, as was requested in #47.