### PR TITLE
Use Libertinus Serif as default serif font

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -1,3 +1,4 @@
+@import url('hxttps://fontlibrary.org/face/libertinus-serif');
 /* ---------------------------------------------------------------------------------------------- */
 /* Make HTML more responsive (adapted from https://fluidity.sexy ← note: broken link)             */
 /* ---------------------------------------------------------------------------------------------- */
@@ -41,8 +42,9 @@ th, thead, tfoot { background: #eee; font-weight: bold; }
 /* ---------------------------------------------------------------------------------------------- */
 /* Additional adjustments (my own)                                                                */
 /* ---------------------------------------------------------------------------------------------- */
-:root { --serif: 'Book Antiqua', 'Palatino', 'Palatino Linotype', 'URW Palladio L', serif; }
+:root { --serif: 'Libertinus Serif', serif; }
 body { font-family: var(--serif); }
+h1, h2, h3, h4, h5, h6 { font-family: 'Libertinus Serif Display'; }
 a[href] { text-decoration: none; } a[href]:hover { text-decoration: underline; }
 a[href], a[href]>b, a[href]>strong { color: RoyalBlue; } /* override "improve contrast" (above) */
 a[href]:visited, a[href]:visited>b, a[href]:visited>strong { color: BlueViolet; }


### PR DESCRIPTION
As mentioned in #15:

> Both Linux Libertine and STIX seem to be quite nice as generic serif fonts. It might be worth [...] considering changing the default, since Palatino is quite wide, and therefore a little bit opinionated.

I've been experimenting personally with [Libertinus Serif](https://github.com/alif-type/libertinus) (the successor of the now dormant Linux Libertine project), and I must say it is indeed quite pleasant and less opinionated than Palatino-like fonts.

Instead of attempting to find similarities in the native font stacks of macOS, Windows and Linux, this PR simply imports the webfont stylesheet from the excellent [Font Library](https://fontlibrary.org) project. There is a flash of unstyled content as the external stylesheet and fonts download, but since this bookmarklet's very premise relies on such a style swap, I don't consider it a deal-breaker.

There may be a slight issue if the stylesheet is being used as a base style for webpages, rather than merely as part of the bookmarklet, but [AFAIK](https://github.com/search?q=downstyler.css&type=Code) nobody is using this style (and they can always make a copy anyway).

One nice extra thing about this is that headings can now benefit from a less heavy bold style by using the 'Libertinus Serif Display' font. The result is really nice.

I'll let this PR sit for a while, as I test-drive the recent fixing of #47, which might alleviate the issues I've been facing lately.

Fixes #15 (and is related to #25).