### PR TITLE
Tweak style (text size limits, font for headings)

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -18,7 +18,7 @@ html { box-sizing: border-box; } *, *:before, *:after { box-sizing: inherit; }
 /* ---------------------------------------------------------------------------------------------- */
 /* Size text according to screen width (adapted from https://css-tricks.com/molten-leading-css/)  */
 /* ---------------------------------------------------------------------------------------------- */
-html { font-size: clamp(0.9rem, calc(13px + 0.5vw), 1.1rem); }
+html { font-size: clamp(1rem, calc(13px + 0.5vw), 1.2rem); }
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Improved typography (adapted from http://bettermotherfuckingwebsite.com)                       */
@@ -44,7 +44,6 @@ th, thead, tfoot { background: #eee; font-weight: bold; }
 /* ---------------------------------------------------------------------------------------------- */
 :root { --serif: 'Libertinus Serif', serif; }
 body { font-family: var(--serif); }
-h1, h2, h3, h4, h5, h6 { font-family: 'Libertinus Serif Display'; }
 a[href] { text-decoration: none; } a[href]:hover { text-decoration: underline; }
 a[href], a[href]>b, a[href]>strong { color: RoyalBlue; } /* override "improve contrast" (above) */
 a[href]:visited, a[href]:visited>b, a[href]:visited>strong { color: BlueViolet; }


### PR DESCRIPTION
Libertinus Serif Display is not as refined as the regular Libertinus font; besides, it deviates from the default appearance of unstyled headings, which are full bold.

The text limits are also raised because they were biased towards small font sizes (possibly a consequence of tests using Palatino).

Follow-up of #54 and #56.