### PR TITLE
Simplify table style

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -34,16 +34,14 @@ b, strong, th { color: #222; } body { color: #333; }
 /* ---------------------------------------------------------------------------------------------- */
 /* Clean table style table (adapted from http://getskeleton.com)                                  */
 /* ---------------------------------------------------------------------------------------------- */
-table { border-collapse: collapse; font-family: sans-serif; font-size: 90%; }
-table *:not(th):not(td){ font-family: var(--serif); font-size: 1rem; line-height: 1.5; }
-th, td { padding-left: .5em; padding-right: 1em; text-align: left; border-bottom: 1px solid #ddd; }
+table { border-collapse: collapse; }
+th, td { padding-left: .5em; padding-right: 1em; text-align: left; }
 th, thead, tfoot { background: #eee; font-weight: bold; }
 
 /* ---------------------------------------------------------------------------------------------- */
 /* Additional adjustments (my own)                                                                */
 /* ---------------------------------------------------------------------------------------------- */
-:root { --serif: 'Libertinus Serif', serif; }
-body { font-family: var(--serif); }
+body { font-family: 'Libertinus Serif', serif; }
 a[href] { text-decoration: none; } a[href]:hover { text-decoration: underline; }
 a[href], a[href]>b, a[href]>strong { color: RoyalBlue; } /* override "improve contrast" (above) */
 a[href]:visited, a[href]:visited>b, a[href]:visited>strong { color: BlueViolet; }


### PR DESCRIPTION
The previous rules were overly complex and against the spirit of a base, default-like style.
Some of them didn't even apply (e.g. the font-family ones).

By removing the sans-serif style for tables, the --serif variable is no longer needed, further simplifying the stylesheet.

Additionally, the removal of the border makes downstyler more suited to handle sites that use tables for layout. This improves on #18, though not fully; in particular, the width is still calculated for the entire body rather than for the central content column typically used in such layouts.