### PR TITLE
Remove font loading from FontLibrary.org

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -1,11 +1,4 @@
 /* ---------------------------------------------------------------------------------------------- */
-/* Use Libertinus Serif as the default font (plus workaround for proper bold instead of semibold) */
-/* ---------------------------------------------------------------------------------------------- */
-@import url('https://fontlibrary.org/face/libertinus-serif');
-body { font-family: 'Libertinus Serif', serif; }
-b, strong, th, h1, h2, h3, h4, h5, h6 { font-family: LibertinusSerifBold; }
-
-/* ---------------------------------------------------------------------------------------------- */
 /* Make HTML more responsive (adapted from https://fluidity.sexy ← note: broken link)             */
 /* ---------------------------------------------------------------------------------------------- */
 img, canvas, iframe, video, svg, select, textarea { max-width: 100%; }
@@ -57,7 +50,8 @@ h6 { color: #666; font-size: 112.25%; /* 2^(1/6) */ }
 /* ---------------------------------------------------------------------------------------------- */
 /* Additional adjustments.                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
-a[href], a[href]>b, a[href]>strong { color: RoyalBlue; } /* override "improve contrast" (above) */
+body { font-family: 'Libertinus Serif', 'Crimson Text', serif; }
+a[href], a[href]>b, a[href]>strong { color: RoyalBlue; } /* override "improved contrast" (above) */
 a[href]:visited, a[href]:visited>b, a[href]:visited>strong { color: BlueViolet; }
 pre, code, kbd, samp, tt { padding: .1em .3em; margin: 0 .1em; font-size: 80%; }
 pre, code, kbd, samp, tt { background: #eee; border: 1px solid #ccc; }


### PR DESCRIPTION
fontlibrary.org is sometimes slow to load, and it's not crucial that downstyler users use Libertinus over the default serif font (which is made nice enough with the typography enhancements of this stylesheet anyway).

Besides, FontLibrary had the semibold version of Libertinus miscategorized as bold, which required the custom workaround added in commit 57102fbd1.

So this PR keeps Libertinus as the main font if it's present in the user's system, but doesn't try to load it if it isn't. This reverts commits 9f4dbf9f1 (from PR #56), daf1a79f4, and 57102fbd1. See also #57, which had already reverted part of #56 (the use of Libertinus Serif Display in headings).

It also adds Crimson Text as an alternative to Libertinus, before falling back to serif.
For comparison, see:
- http://typopro.org/specimen/specimen.html#TypoPRO_0_Libertinus_0_Serif-normal-normal-normal-normal
- http://typopro.org/specimen/specimen.html#TypoPRO_0_Crimson-normal-normal-normal-normal