### PR TITLE
Fix link to raw HTML demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ which (with various degrees of —ahem— enthusiasm)
 praise the merits of plain HTML as a format for rich documents.
 
 Here's a live comparison of how plain a variety of HTML markup looks with the various "base" stylesheets:
-- [no style (browser default)](https://waldyrious.github.io/downstyler/comparison/demo-raw.xhtml)
+- [no style (browser default)](https://waldyrious.github.io/downstyler/comparisons/demo-raw.xhtml)
 - [reset](https://waldyrious.github.io/downstyler/comparisons/demo-reset.xhtml)
 - [sanitize](https://waldyrious.github.io/downstyler/comparisons/demo-sanitize.xhtml)
 - [normalize](https://waldyrious.github.io/downstyler/comparisons/demo-normalize.xhtml)


### PR DESCRIPTION
Fixed a link that resulted in a `404 - File not found` page by changing `/comparison/` to `/comparisons/`.