### PR TITLE
Make MIME type explicit in bookmarklet code

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -55,7 +55,7 @@
           for(tb of document.getElementsByTagName('table')){tb.border=0}
           for(ft of document.getElementsByTagName('font')){for(at of ft.attributes){ft.removeAttribute(at.name);}}
           document.head.insertAdjacentHTML('beforeend',
-            '&lt;link rel=&quot;stylesheet&quot; href=&quot;'+
+            '&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;'+
               (window.location.protocol.startsWith('http')?window.location.protocol:'http:')+
               '//raw.githack.com/waldyrious/downstyler/master/downstyler.css'+
             '&quot; /&gt;'
@@ -83,7 +83,7 @@
           for(tb of document.getElementsByTagName('table')){tb.border=0}
           for(ft of document.getElementsByTagName('font')){for(at of ft.attributes){ft.removeAttribute(at.name);}}
           document.head.insertAdjacentHTML('beforeend',
-            '&lt;link rel=&quot;stylesheet&quot; href=&quot;'+
+            '&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot href=&quot;'+
               (window.location.protocol.startsWith('http')?window.location.protocol:'http:')+
               '//raw.githack.com/waldyrious/downstyler/master/downstyler.css'+
             '&quot; /&gt;'


### PR DESCRIPTION
Add the `type="text/css"` attribute to the `<link rel="stylesheet">` tag in the code of the bookmarklets.

Without this MIME type being explicitly indicated, the browser assumes the resource to be of the default type (text/plain) in websites with the `X-Content-Type-Options: nosniff` header, resulting in blocking of the resource, and the following error in the console:

> The resource from "https//raw.githack.com/waldyrious/downstyler/master/downstyler.css"
> was blocked due to MIME type mismatch (X-Content-Type-Options: nosniff).