### PR TITLE
Move text justification from paperlike variant to base style

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -47,7 +47,7 @@ h6 { color: #666; font-size: 112.25%; /* 2^(1/6) */ }
 /* ---------------------------------------------------------------------------------------------- */
 /* Additional adjustments.                                                                        */
 /* ---------------------------------------------------------------------------------------------- */
-body { font-family: 'Libertinus Serif', 'Crimson Text', serif; }
+body { font-family: 'Libertinus Serif', 'Crimson Text', serif; text-align: justify; hyphens: auto; }
 pre, code, kbd, samp, tt { padding: .1em .3em; margin: 0 .1em; font-size: 80%; }
 pre, code, kbd, samp, tt { background: #eee; border: 1px solid #ccc; }
 pre > code { border: none; margin: 0; padding: 0; font-size: 100%; }

--- a/index.xhtml
+++ b/index.xhtml
@@ -109,7 +109,7 @@
               html { background: #ddd; }
               body {
                  background: linear-gradient( to right, #f9f9f9, #fff 10%, #fff 90%, #f9f9f9 100% );
-                 filter: sepia(3%) saturate(85%) contrast(98%); text-align: justify; hyphens: auto;
+                 filter: sepia(3%) saturate(85%) contrast(98%);
                  max-width: 40em; padding: 1em 5em; margin: 10px auto; border-radius: 3px; box-shadow: 0 0 7px -3px;
               }
               h1, h2, h3, h4, h5, h6 { text-align: initial; }


### PR DESCRIPTION
I recall reading a long time ago that unjustified (i.e. left-aligned) text is supposedly easier to read without losing one's place when moving from line to line (and indeed that's what browsers do by default). However, we're already limiting to the max line length for essentially the same reasons. In fact, that is precisely allows the paperlike variant (an printed media in general) to work well with text justification.

Therefore, in this PR I'm moving the text justification to the base style. I'll leave this open for a few days in case someone wants to comment.
