### PR TITLE
Simplify code-related styles

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -76,9 +76,7 @@ a[href] { color: RoyalBlue; }
 a[href]:visited { color: BlueViolet; }
 
 /* Styles for code-related elements */
-pre, code, kbd, samp, tt { padding: .1em .3em; margin: 0 .1em; font-size: 80%; }
-pre, code, kbd, samp, tt { background: #eee; border: 1px solid #ccc; }
-pre > code { border: none; margin: 0; padding: 0; font-size: 100%; }
+pre, :not(pre) code, kbd, samp, tt { padding: .1em .3em; margin: 0 .1em; font-size: 80%; background: #eee; }
 
 /* Styles for blockquote elements */
 blockquote { padding-left: 1em; margin-left: 0; border-left: 5px solid #ddd; color: #666; }


### PR DESCRIPTION
- Remove border (too opinionated; background is sufficient to make them stand out)
- Merge two lines into a single one (partially reverts 48c0c8fe84475245b9f0913929b3744c47cf12ba)
- Improve `pre > code` rule (introduced in b5e86b2f839d04dd068a9fdc83d8040d154f22e0) by integrating it into the primary rule via `:not`, rather than have it as a separate "anti-rule"