### PR TITLE
Add FreeSerif to the list of serif fonts

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -34,7 +34,7 @@ h5 { color: #555; font-size: 125.99%; /* 2^(2/6) */ }
 h6 { color: #666; font-size: 112.25%; /* 2^(1/6) */ }
 
 /* Use nicer serif fonts, if available */
-body { font-family: 'Libertinus Serif', 'Crimson Text', serif; }
+body { font-family: 'Libertinus Serif', 'Crimson Text', FreeSerif, serif; }
 
 /* ------------------------------------------------------------------------------------------------------------------ */
 /* Simple table style                                                                                                 */


### PR DESCRIPTION
See https://github.com/dbohdan/classless-css/issues/13#issuecomment-808435579.

/cc @dbohdan. I'd be happy to consider additional suggestions, though my goal is to include generic-looking (though visually pleasant) serif fonts that not deviate too much from the style of the Times / Times New Roman default serif font. For example, I'm not inclined to consider "wide serif" fonts like Georgia or Palatino, nor fonts with a very marked style.