### PR TITLE
Customize selection color

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -80,3 +80,6 @@ pre, :not(pre) code, kbd, samp, tt { padding: .1em .3em; margin: 0 .1em; font-si
 
 /* Styles for blockquote elements */
 blockquote { padding-left: 1em; margin-left: 0; border-left: 5px solid #ddd; color: #666; }
+
+/* Softer selection color that works over text and links without the color inversion effect */
+::selection { background-color: #def; }


### PR DESCRIPTION
This has been bothering me in Ubuntu, which ships a version of Firefox that uses orange for highlighting selections.

But even the usual intense blue that's used by most browsers by default (with text in white, creating a "inverted colors" effect) is not a good default, since it doesn't play well with link colors, which firstly become the same color as the text (white) and secondly, get styled in an awkward way due to the underline color not being styleable differently within the selection:

| Firefox @ Ubuntu | Chromium-based browser (Brave) |
|------------------|--------------------------------|
| ![Screenshot from 2021-11-22 20-43-00](https://user-images.githubusercontent.com/478237/142933362-44edafe2-3416-4313-ad0f-21b8966e1b61.png) | ![Screenshot from 2021-11-22 20-43-20](https://user-images.githubusercontent.com/478237/142933366-99d0570b-5b64-4b8f-81a1-db87fe7f284c.png)
| ![Screenshot from 2021-11-22 20-45-35](https://user-images.githubusercontent.com/478237/142933368-9ec72c14-e253-4397-b360-39c4df56710a.png) | ![Screenshot from 2021-11-22 20-45-47](https://user-images.githubusercontent.com/478237/142933373-ccb2fa89-b183-48a0-8662-bfcb4315a82a.png) |