### PR TITLE
Limit hyphens and text justification to paragraphs

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -18,7 +18,8 @@ html { box-sizing: border-box; }
 html { font-size: clamp(1rem, calc(13px + 0.5vw), 1.2rem); }
 
 /* Improved text layout and spacing (adapted from http://bettermotherfuckingwebsite.com) */
-body { line-height: 1.5; text-align: justify; hyphens: auto; margin: 0 auto; max-width: 40em; padding: 1em; }
+body { line-height: 1.5; margin: 0 auto; max-width: 40em; padding: 1em; }
+p { text-align: justify; hyphens: auto; }
 h1, h2, h3, h4, h5, h6 { margin-top: 1em; margin-bottom: 0.5em; line-height: 1.2; }
 
 /* Improved contrast (adapted from https://jgthms.com/web-design-in-4-minutes/#color-contrast) */


### PR DESCRIPTION
Non-paragraphs don't always play well with hyphenization. Example, from [this blog post](https://julialang.org/blog/2022/04/simple-chains/):

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/478237/163454666-3a6e70da-97b1-4308-b0ef-b6b67640d939.png) |![image](https://user-images.githubusercontent.com/478237/163454855-ec98f81f-016b-4e76-8479-0574622e22ce.png) |

This particular case could be a browser bug (the text of the heading does get hyphenized if I manually introduce `&shy;` characters), but it's better to be deliberate and target elements that are specifically aimed for prose.

Follow-up of #64.