### PR TITLE
Fix centering in project homepage

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -6,7 +6,7 @@
     <title>Downstyler: a tool to fight CSS bloat</title>
     <link rel="stylesheet" href="downstyler.css" />
     <style>
-      body {
+      body * {
         text-align: center;
         hyphens: auto;
       }


### PR DESCRIPTION
The previous definition was overridden by the more specific selector that was introduced in e2b3a38 (#75).