### PR TITLE
Change style of section separators in the demo pages

### DIFF
--- a/comparisons/demo-bettermfwebsite.xhtml
+++ b/comparisons/demo-bettermfwebsite.xhtml
@@ -8,8 +8,7 @@
     <style>.highlight {
     text-align: center;
     text-transform: uppercase;
-    font-family: sans-serif;
-    font-size: 1rem;
+    font: bold 1rem sans-serif;
     color: whitesmoke;
     background-color: dimgrey;
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
@@ -17,6 +16,8 @@
     width: 100vw;
     margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
+    margin-bottom: 0.5em;
+    clear: both;
     }</style>
   </head>
   <body>

--- a/comparisons/demo-bettermfwebsite.xhtml
+++ b/comparisons/demo-bettermfwebsite.xhtml
@@ -10,9 +10,12 @@
     text-transform: uppercase;
     font-family: sans-serif;
     font-size: 1rem;
-    color: silver;
-    border-top: 1px dashed silver;
+    color: whitesmoke;
+    background-color: dimgrey;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
     padding: .5em;
+    width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
     }</style>
   </head>

--- a/comparisons/demo-downstyler.xhtml
+++ b/comparisons/demo-downstyler.xhtml
@@ -8,8 +8,7 @@
     <style>.highlight {
     text-align: center;
     text-transform: uppercase;
-    font-family: sans-serif;
-    font-size: 1rem;
+    font: bold 1rem sans-serif;
     color: whitesmoke;
     background-color: dimgrey;
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
@@ -17,6 +16,8 @@
     width: 100vw;
     margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
+    margin-bottom: 0.5em;
+    clear: both;
     }</style>
   </head>
   <body>

--- a/comparisons/demo-downstyler.xhtml
+++ b/comparisons/demo-downstyler.xhtml
@@ -10,9 +10,12 @@
     text-transform: uppercase;
     font-family: sans-serif;
     font-size: 1rem;
-    color: silver;
-    border-top: 1px dashed silver;
+    color: whitesmoke;
+    background-color: dimgrey;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
     padding: .5em;
+    width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
     }</style>
   </head>

--- a/comparisons/demo-normalize.xhtml
+++ b/comparisons/demo-normalize.xhtml
@@ -8,8 +8,7 @@
     <style>.highlight {
     text-align: center;
     text-transform: uppercase;
-    font-family: sans-serif;
-    font-size: 1rem;
+    font: bold 1rem sans-serif;
     color: whitesmoke;
     background-color: dimgrey;
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
@@ -17,6 +16,8 @@
     width: 100vw;
     margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
+    margin-bottom: 0.5em;
+    clear: both;
     }</style>
   </head>
   <body>

--- a/comparisons/demo-normalize.xhtml
+++ b/comparisons/demo-normalize.xhtml
@@ -10,9 +10,12 @@
     text-transform: uppercase;
     font-family: sans-serif;
     font-size: 1rem;
-    color: silver;
-    border-top: 1px dashed silver;
+    color: whitesmoke;
+    background-color: dimgrey;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
     padding: .5em;
+    width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
     }</style>
   </head>

--- a/comparisons/demo-raw.xhtml
+++ b/comparisons/demo-raw.xhtml
@@ -7,8 +7,7 @@
     <style>.highlight {
     text-align: center;
     text-transform: uppercase;
-    font-family: sans-serif;
-    font-size: 1rem;
+    font: bold 1rem sans-serif;
     color: whitesmoke;
     background-color: dimgrey;
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
@@ -16,6 +15,8 @@
     width: 100vw;
     margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
+    margin-bottom: 0.5em;
+    clear: both;
     }</style>
   </head>
   <body>

--- a/comparisons/demo-raw.xhtml
+++ b/comparisons/demo-raw.xhtml
@@ -9,9 +9,12 @@
     text-transform: uppercase;
     font-family: sans-serif;
     font-size: 1rem;
-    color: silver;
-    border-top: 1px dashed silver;
+    color: whitesmoke;
+    background-color: dimgrey;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
     padding: .5em;
+    width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
     }</style>
   </head>

--- a/comparisons/demo-reset.xhtml
+++ b/comparisons/demo-reset.xhtml
@@ -8,8 +8,7 @@
     <style>.highlight {
     text-align: center;
     text-transform: uppercase;
-    font-family: sans-serif;
-    font-size: 1rem;
+    font: bold 1rem sans-serif;
     color: whitesmoke;
     background-color: dimgrey;
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
@@ -17,6 +16,8 @@
     width: 100vw;
     margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
+    margin-bottom: 0.5em;
+    clear: both;
     }</style>
   </head>
   <body>

--- a/comparisons/demo-reset.xhtml
+++ b/comparisons/demo-reset.xhtml
@@ -10,9 +10,12 @@
     text-transform: uppercase;
     font-family: sans-serif;
     font-size: 1rem;
-    color: silver;
-    border-top: 1px dashed silver;
+    color: whitesmoke;
+    background-color: dimgrey;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
     padding: .5em;
+    width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
     }</style>
   </head>

--- a/comparisons/demo-sanitize.xhtml
+++ b/comparisons/demo-sanitize.xhtml
@@ -8,8 +8,7 @@
     <style>.highlight {
     text-align: center;
     text-transform: uppercase;
-    font-family: sans-serif;
-    font-size: 1rem;
+    font: bold 1rem sans-serif;
     color: whitesmoke;
     background-color: dimgrey;
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
@@ -17,6 +16,8 @@
     width: 100vw;
     margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
+    margin-bottom: 0.5em;
+    clear: both;
     }</style>
   </head>
   <body>

--- a/comparisons/demo-sanitize.xhtml
+++ b/comparisons/demo-sanitize.xhtml
@@ -10,9 +10,12 @@
     text-transform: uppercase;
     font-family: sans-serif;
     font-size: 1rem;
-    color: silver;
-    border-top: 1px dashed silver;
+    color: whitesmoke;
+    background-color: dimgrey;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.75);
     padding: .5em;
+    width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     margin-top: 2em;
     }</style>
   </head>


### PR DESCRIPTION
- Change style of section separators in the demo pages: make them stand out as outside the page content flow; use colors that provide adequate contrast (WCAG-compatible)
- Adjust styling of demo page dividers to work in the reset demo
  - The default `font-weight` and `margin-bottom` properties for headings are reset from the typical browser defaults, so they need to be specified explicitly
  - Images get floated, so the section dividers need a `clear` property