### PR TITLE
Improve form styling

### DIFF
--- a/comparisons/demo-bettermfwebsite.xhtml
+++ b/comparisons/demo-bettermfwebsite.xhtml
@@ -318,6 +318,7 @@
         <label for="check_three">Amet adipisci 2:</label>
         <input tabindex="12" type="checkbox" name="checkSet" value="three" id="check_three" />
         <input tabindex="13" type="submit" name="submit" value="Submit" />
+        <button>Button</button>
       </fieldset>
     </form>
   </body>

--- a/comparisons/demo-downstyler.xhtml
+++ b/comparisons/demo-downstyler.xhtml
@@ -318,6 +318,7 @@
         <label for="check_three">Amet adipisci 2:</label>
         <input tabindex="12" type="checkbox" name="checkSet" value="three" id="check_three" />
         <input tabindex="13" type="submit" name="submit" value="Submit" />
+        <button>Button</button>
       </fieldset>
     </form>
   </body>

--- a/comparisons/demo-normalize.xhtml
+++ b/comparisons/demo-normalize.xhtml
@@ -318,6 +318,7 @@
         <label for="check_three">Amet adipisci 2:</label>
         <input tabindex="12" type="checkbox" name="checkSet" value="three" id="check_three" />
         <input tabindex="13" type="submit" name="submit" value="Submit" />
+        <button>Button</button>
       </fieldset>
     </form>
   </body>

--- a/comparisons/demo-raw.xhtml
+++ b/comparisons/demo-raw.xhtml
@@ -317,6 +317,7 @@
         <label for="check_three">Amet adipisci 2:</label>
         <input tabindex="12" type="checkbox" name="checkSet" value="three" id="check_three" />
         <input tabindex="13" type="submit" name="submit" value="Submit" />
+        <button>Button</button>
       </fieldset>
     </form>
   </body>

--- a/comparisons/demo-reset.xhtml
+++ b/comparisons/demo-reset.xhtml
@@ -318,6 +318,7 @@
         <label for="check_three">Amet adipisci 2:</label>
         <input tabindex="12" type="checkbox" name="checkSet" value="three" id="check_three" />
         <input tabindex="13" type="submit" name="submit" value="Submit" />
+        <button>Button</button>
       </fieldset>
     </form>
   </body>

--- a/comparisons/demo-sanitize.xhtml
+++ b/comparisons/demo-sanitize.xhtml
@@ -318,6 +318,7 @@
         <label for="check_three">Amet adipisci 2:</label>
         <input tabindex="12" type="checkbox" name="checkSet" value="three" id="check_three" />
         <input tabindex="13" type="submit" name="submit" value="Submit" />
+        <button>Button</button>
       </fieldset>
     </form>
   </body>

--- a/downstyler.css
+++ b/downstyler.css
@@ -51,8 +51,7 @@ th, thead, tfoot { background: #eee; font-weight: bold; }
 /* ------------------------------------------------------------------------------------------------------------------ */
 
 textarea { vertical-align: text-top; }
-textarea, input[type=text], input:not([type]) { font-family: monospace; font-size: 80%; }
-input[type] { font-family: sans-serif; font-size: 100%; }
+input, textarea, select, button { font-family: inherit; font-size: 100%; }
 
 /* ------------------------------------------------------------------------------------------------------------------ */
 /* Images and figures                                                                                                 */


### PR DESCRIPTION
Inspired by [normalize.css](https://github.com/necolas/normalize.css/)'s form styles, as seen in [destyle.css](https://github.com/nicolas-cusan/destyle.css/)' [comparison page](https://nicolas-cusan.github.io/destyle.css/compare.html), and to a less useful degree, in [our own demo page](https://waldyrious.net/downstyler/comparisons/demo-normalize.xhtml#forms):
- Inherit the document's font style
- Use 100% font size
- Uniform formatting for all form elements

Addresses #5 (but probably additional styles are still needed for layout, margins, etc.