### PR TITLE
Make <textarea> a block-type element with 100% width

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -50,7 +50,7 @@ th, thead, tfoot { background: #eee; font-weight: bold; }
 /* Forms and form inputs (work in progress, see https://github.com/waldyrious/downstyler/issues/5)                    */
 /* ------------------------------------------------------------------------------------------------------------------ */
 
-textarea { vertical-align: top; }
+textarea { display: block; width: 100%; }
 input, textarea, select, button { font-family: inherit; font-size: 100%; margin: 0.2em 0; }
 
 /* ------------------------------------------------------------------------------------------------------------------ */


### PR DESCRIPTION
### Screenshots

Chromium-based:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/waldyrious/downstyler/assets/478237/f90289db-a2d0-4c3d-8e4c-217781f2acc3) | ![image](https://github.com/waldyrious/downstyler/assets/478237/55e64240-fb6a-4078-a598-e23cff5fd73c) |

Firefox:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/waldyrious/downstyler/assets/478237/7608397a-fa30-4f11-9e8d-6973438dc86d) | ![image](https://github.com/waldyrious/downstyler/assets/478237/0c60aeda-9c8a-4a31-a865-91bd98b8585a) |