### PR TITLE
Make mutliline <select> elements be top-aligned

### DIFF
--- a/comparisons/demo-bettermfwebsite.xhtml
+++ b/comparisons/demo-bettermfwebsite.xhtml
@@ -277,16 +277,16 @@
         <input tabindex="3" id="Email" type="text" name="Email" placeholder="john@email.net"/>
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
-        <label for="Lorem">Message:</label>
-        <select tabindex="5" id="Lorem" name="Lorem ipsum">
+        <label for="select-foo">Foo:</label>
+        <select tabindex="5" id="select-foo" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
           <option value="4">Vitae diam</option>
           <option value="5">Vestibulum ornare</option>
         </select>
-        <label for="Pellentesque">Pellentesque habitant:</label>
-        <select tabindex="6" id="Pellentesque" size="1" name="select">
+        <label for="select-bar">Bar:</label>
+        <select tabindex="6" id="select-bar" size="1" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-bettermfwebsite.xhtml
+++ b/comparisons/demo-bettermfwebsite.xhtml
@@ -278,7 +278,7 @@
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
         <label for="select-foo">Foo:</label>
-        <select tabindex="5" id="select-foo" name="Select foo">
+        <select tabindex="5" id="select-foo" size="1" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
@@ -286,7 +286,7 @@
           <option value="5">Vestibulum ornare</option>
         </select>
         <label for="select-bar">Bar:</label>
-        <select tabindex="6" id="select-bar" size="1" name="Select bar">
+        <select tabindex="6" id="select-bar" size="3" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-downstyler.xhtml
+++ b/comparisons/demo-downstyler.xhtml
@@ -277,16 +277,16 @@
         <input tabindex="3" id="Email" type="text" name="Email" placeholder="john@email.net"/>
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
-        <label for="Lorem">Message:</label>
-        <select tabindex="5" id="Lorem" name="Lorem ipsum">
+        <label for="select-foo">Foo:</label>
+        <select tabindex="5" id="select-foo" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
           <option value="4">Vitae diam</option>
           <option value="5">Vestibulum ornare</option>
         </select>
-        <label for="Pellentesque">Pellentesque habitant:</label>
-        <select tabindex="6" id="Pellentesque" size="1" name="select">
+        <label for="select-bar">Bar:</label>
+        <select tabindex="6" id="select-bar" size="1" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-downstyler.xhtml
+++ b/comparisons/demo-downstyler.xhtml
@@ -278,7 +278,7 @@
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
         <label for="select-foo">Foo:</label>
-        <select tabindex="5" id="select-foo" name="Select foo">
+        <select tabindex="5" id="select-foo" size="1" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
@@ -286,7 +286,7 @@
           <option value="5">Vestibulum ornare</option>
         </select>
         <label for="select-bar">Bar:</label>
-        <select tabindex="6" id="select-bar" size="1" name="Select bar">
+        <select tabindex="6" id="select-bar" size="3" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-normalize.xhtml
+++ b/comparisons/demo-normalize.xhtml
@@ -277,16 +277,16 @@
         <input tabindex="3" id="Email" type="text" name="Email" placeholder="john@email.net"/>
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
-        <label for="Lorem">Message:</label>
-        <select tabindex="5" id="Lorem" name="Lorem ipsum">
+        <label for="select-foo">Foo:</label>
+        <select tabindex="5" id="select-foo" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
           <option value="4">Vitae diam</option>
           <option value="5">Vestibulum ornare</option>
         </select>
-        <label for="Pellentesque">Pellentesque habitant:</label>
-        <select tabindex="6" id="Pellentesque" size="1" name="select">
+        <label for="select-bar">Bar:</label>
+        <select tabindex="6" id="select-bar" size="1" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-normalize.xhtml
+++ b/comparisons/demo-normalize.xhtml
@@ -278,7 +278,7 @@
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
         <label for="select-foo">Foo:</label>
-        <select tabindex="5" id="select-foo" name="Select foo">
+        <select tabindex="5" id="select-foo" size="1" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
@@ -286,7 +286,7 @@
           <option value="5">Vestibulum ornare</option>
         </select>
         <label for="select-bar">Bar:</label>
-        <select tabindex="6" id="select-bar" size="1" name="Select bar">
+        <select tabindex="6" id="select-bar" size="3" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-raw.xhtml
+++ b/comparisons/demo-raw.xhtml
@@ -276,16 +276,16 @@
         <input tabindex="3" id="Email" type="text" name="Email" placeholder="john@email.net"/>
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
-        <label for="Lorem">Message:</label>
-        <select tabindex="5" id="Lorem" name="Lorem ipsum">
+        <label for="select-foo">Foo:</label>
+        <select tabindex="5" id="select-foo" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
           <option value="4">Vitae diam</option>
           <option value="5">Vestibulum ornare</option>
         </select>
-        <label for="Pellentesque">Pellentesque habitant:</label>
-        <select tabindex="6" id="Pellentesque" size="1" name="select">
+        <label for="select-bar">Bar:</label>
+        <select tabindex="6" id="select-bar" size="1" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-raw.xhtml
+++ b/comparisons/demo-raw.xhtml
@@ -277,7 +277,7 @@
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
         <label for="select-foo">Foo:</label>
-        <select tabindex="5" id="select-foo" name="Select foo">
+        <select tabindex="5" id="select-foo" size="1" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
@@ -285,7 +285,7 @@
           <option value="5">Vestibulum ornare</option>
         </select>
         <label for="select-bar">Bar:</label>
-        <select tabindex="6" id="select-bar" size="1" name="Select bar">
+        <select tabindex="6" id="select-bar" size="3" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-reset.xhtml
+++ b/comparisons/demo-reset.xhtml
@@ -277,16 +277,16 @@
         <input tabindex="3" id="Email" type="text" name="Email" placeholder="john@email.net"/>
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
-        <label for="Lorem">Message:</label>
-        <select tabindex="5" id="Lorem" name="Lorem ipsum">
+        <label for="select-foo">Foo:</label>
+        <select tabindex="5" id="select-foo" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
           <option value="4">Vitae diam</option>
           <option value="5">Vestibulum ornare</option>
         </select>
-        <label for="Pellentesque">Pellentesque habitant:</label>
-        <select tabindex="6" id="Pellentesque" size="1" name="select">
+        <label for="select-bar">Bar:</label>
+        <select tabindex="6" id="select-bar" size="1" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-reset.xhtml
+++ b/comparisons/demo-reset.xhtml
@@ -278,7 +278,7 @@
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
         <label for="select-foo">Foo:</label>
-        <select tabindex="5" id="select-foo" name="Select foo">
+        <select tabindex="5" id="select-foo" size="1" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
@@ -286,7 +286,7 @@
           <option value="5">Vestibulum ornare</option>
         </select>
         <label for="select-bar">Bar:</label>
-        <select tabindex="6" id="select-bar" size="1" name="Select bar">
+        <select tabindex="6" id="select-bar" size="3" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-sanitize.xhtml
+++ b/comparisons/demo-sanitize.xhtml
@@ -277,16 +277,16 @@
         <input tabindex="3" id="Email" type="text" name="Email" placeholder="john@email.net"/>
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
-        <label for="Lorem">Message:</label>
-        <select tabindex="5" id="Lorem" name="Lorem ipsum">
+        <label for="select-foo">Foo:</label>
+        <select tabindex="5" id="select-foo" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
           <option value="4">Vitae diam</option>
           <option value="5">Vestibulum ornare</option>
         </select>
-        <label for="Pellentesque">Pellentesque habitant:</label>
-        <select tabindex="6" id="Pellentesque" size="1" name="select">
+        <label for="select-bar">Bar:</label>
+        <select tabindex="6" id="select-bar" size="1" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/comparisons/demo-sanitize.xhtml
+++ b/comparisons/demo-sanitize.xhtml
@@ -278,7 +278,7 @@
         <label for="Message">Message:</label>
         <textarea tabindex="4" id="Message" name="Message" placeholder="Hello, world!"></textarea>
         <label for="select-foo">Foo:</label>
-        <select tabindex="5" id="select-foo" name="Select foo">
+        <select tabindex="5" id="select-foo" size="1" name="Select foo">
           <option selected="selected" value="1">Lorem ipsum</option>
           <option value="2">Dolor sit amet</option>
           <option value="3">Consectetuer adipiscing</option>
@@ -286,7 +286,7 @@
           <option value="5">Vestibulum ornare</option>
         </select>
         <label for="select-bar">Bar:</label>
-        <select tabindex="6" id="select-bar" size="1" name="Select bar">
+        <select tabindex="6" id="select-bar" size="3" name="Select bar">
           <optgroup label="Lorem ipsum 1">
             <option selected="selected" value="1">Nunc urna nulla</option>
             <option value="2">Ultrices sit amet</option>

--- a/downstyler.css
+++ b/downstyler.css
@@ -52,6 +52,7 @@ th, thead, tfoot { background: #eee; font-weight: bold; }
 
 textarea { display: block; width: 100%; }
 input, textarea, select, button { font-family: inherit; font-size: 100%; margin: 0.2em 0; }
+select[size]:not([size="1"]) { vertical-align: top; }
 
 /* ------------------------------------------------------------------------------------------------------------------ */
 /* Images and figures                                                                                                 */


### PR DESCRIPTION
- Improve markup of the `<select>` form elements
- Make mutliline `<select>` elements be top-aligned

### Screenshots

Chromium-based:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/waldyrious/downstyler/assets/478237/1101afe9-2f34-469e-9e28-e011168535c3) | ![image](https://github.com/waldyrious/downstyler/assets/478237/69763e05-8c9e-4628-9e26-4ed5900a4fb4) |

Firefox:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/waldyrious/downstyler/assets/478237/4584485e-9d34-413d-8446-e527baffd9fa) | ![image](https://github.com/waldyrious/downstyler/assets/478237/83b6cac7-0c7e-4607-8429-7b6b073300b5) |