### PR TITLE
Adjust custom selection color

### DIFF
--- a/downstyler.css
+++ b/downstyler.css
@@ -84,4 +84,4 @@ pre, :not(pre) code, kbd, samp, tt { padding: .1em .3em; margin: 0 .1em; font-si
 blockquote { padding-left: 1em; margin-left: 0; border-left: 5px solid #ddd; color: #666; }
 
 /* Softer selection color that works over text and links without the color inversion effect */
-::selection { background-color: #def; }
+::selection { background-color: rgba(35%, 75%, 100%, 0.3); }


### PR DESCRIPTION
This is a follow-up of #70.

The previous color did not work well when the elements had non-white backgrounds — in particular, the light gray of table headers and code blocks. By using a stronger blue, the selection is properly visible in elements with both white and lightly tinted backgrounds.

Screenshots:

| Before | After |
| ------ | ----- |
| <img width="1168" height="869" alt="image" src="https://github.com/user-attachments/assets/2633bcb4-a0e7-47c6-9f36-6512a3224d7b" /> | <img width="1168" height="869" alt="image" src="https://github.com/user-attachments/assets/c1fa99da-bba8-4ebc-8095-3296b9db5d8e" /> |